### PR TITLE
Bump to python:3-alpine; fixes #4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:2-alpine
+FROM python:3-alpine
 
-LABEL version="1.0.0"
+LABEL version="1.0.1"
 LABEL repository="http://github.com/max/secret-scan"
 LABEL homepage="http://github.com/max/secret-scan"
 LABEL maintainer="Max Schoening <max@max.wtf>"


### PR DESCRIPTION
### Problem
`truffleHog` is failing to install via `pip` on `python:2-alpine`.

### Solution
Bump to `pytyhon:3-alpine`.