### PR TITLE
Improve Dockerfile with Hadolint suggestions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM python:3-alpine
 
-RUN pip install truffleHog
-
-RUN apk --update add git less openssh && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm /var/cache/apk/*
+# hadolint ignore=DL3013,DL3018
+RUN pip install --no-cache-dir truffleHog && \
+    apk add --no-cache git less openssh
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 


### PR DESCRIPTION
This PR updates the Dockerfile according to Hadolint suggestions.

The ignored checks (3013 and 3018) are related to pinning package versions.

Before:

```text
docker run --rm -i hadolint/hadolint < Dockerfile
-:3 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`
-:3 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`
-:5 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
-:5 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
-:5 DL3019 info: Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages
```

After:

```text
docker run --rm -i hadolint/hadolint < Dockerfile

```

...no complaints :D