### PR TITLE
Add parameter to allow configured secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ jobs:
 
 ## Example with path filters
 
+Use path filters to manage the set of objects that will be scanned.
+
 ```yaml
 on: push
 name: Find Secrets
@@ -31,4 +33,21 @@ jobs:
           exclude_path: 'configuration/exclude_paths.txt'
 ```
 
-For more information about the format of the configuration files for include or exclude paths, please refer to [TruffleHog](https://github.com/dxa4481/truffleHog).
+## Example with allowed patterns
+
+Use a JSON file to allow secrets that shouldn't trigger a warning.
+
+```yaml
+on: push
+name: Find Secrets
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: max/secret-scan@master
+        with:
+          allowed_patterns: 'configuration/allowed_patterns.json'
+```
+
+For more information about the format of the configuration files for each additional parameter, please refer to [truffleHog](https://github.com/trufflesecurity/truffleHog) documentation.

--- a/action.yml
+++ b/action.yml
@@ -2,11 +2,14 @@ name: "Secret Scan"
 description: "Scan your repository for secrets"
 author: "Max Schoening <max@max.wtf>"
 inputs:
-  include_path:  
+  include_path:
     description: 'Path to the configuration file with include path patterns'
     required: false
-  exclude_path:  
+  exclude_path:
     description: 'Path to the configuration file with exclude path patterns'
+    required: false
+  allowed_patterns:
+    description: 'Path to the configuration file with allowed patterns'
     required: false
 runs:
   using: "docker"
@@ -14,6 +17,7 @@ runs:
   args:
     - ${{ inputs.include_path }}
     - ${{ inputs.exclude_path }}
+    - ${{ inputs.allowed_patterns }}
 branding:
   icon: lock
   color: red

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,16 +2,21 @@
 
 set -e
 
-if [ -f "$INPUT_INCLUDE_PATH" ] && [[ -f "$INPUT_EXCLUDE_PATH" ]]; then
-    echo "Running TruffleHog with include and exclude paths."
-    trufflehog --include_paths $INPUT_INCLUDE_PATH --exclude_paths $INPUT_EXCLUDE_PATH $GITHUB_WORKSPACE
-elif [ -f "$INPUT_INCLUDE_PATH" ] ; then
-    echo "Running TruffleHog with include paths."
-    trufflehog --include_paths $INPUT_INCLUDE_PATH $GITHUB_WORKSPACE
-elif [ -f "$INPUT_EXCLUDE_PATH" ] ; then
-    echo "Running TruffleHog with exclude paths."
-    trufflehog --exclude_paths $INPUT_EXCLUDE_PATH $GITHUB_WORKSPACE
-else
-    echo "Running TruffleHog without path filters."
-    trufflehog $GITHUB_WORKSPACE
-fi
+# https://github.com/koalaman/shellcheck/wiki/Sc2086#exceptions
+# https://wiki.bash-hackers.org/syntax/pe#use_an_alternate_value
+# https://unix.stackexchange.com/questions/131766/why-does-my-shell-script-choke-on-whitespace-or-other-special-characters/131767#131767
+# Prepare the command
+set -- trufflehog
+set -- "$@" ${INPUT_INCLUDE_PATH:+--include_paths "$INPUT_INCLUDE_PATH"}
+set -- "$@" ${INPUT_EXCLUDE_PATH:+--exclude_paths "$INPUT_EXCLUDE_PATH"}
+set -- "$@" ${INPUT_ALLOWED_PATTERNS:+--allow "$INPUT_ALLOWED_PATTERNS"}
+set -- "$@" "$GITHUB_WORKSPACE"
+
+# Print the command
+cat << COMMAND > /dev/stdout
+Running truffleHog with command:
+$@
+COMMAND
+
+# Run the command
+"$@"


### PR DESCRIPTION
Hello :)

This PR adds a new parameter `allowed_patterns` that can be configured with a JSON file. This can be used to avoid failed runs when we want to have a secret (like test keys) in the repository.

I tested it with your own repository, using this pattern file:

```json
{
  "some key": "1:283108921048:web:d2bd16290170357a9391da",
  "other key": "1:283108921048:web:d2bd16290170357a9391ad"
}
```

Regarding the refactor of `entrypoint.sh`, I started fixing a few shellcheck warnings and got to a point where I couldn't fix it while keeping the old style. So I rewrote it :sweat: 